### PR TITLE
Update key entries in sprayCloudProperties

### DIFF
--- a/ECN_Spray_A/constant/sprayCloudProperties
+++ b/ECN_Spray_A/constant/sprayCloudProperties
@@ -86,8 +86,8 @@ subModels
             parcelBasisType mass;
             injectionMethod cylinder;
             flowType        flowRateAndDischarge;
-            dInner          0e-6;
-            dOuter          450.0e-6;
+            dInnerCylinder  0e-6;
+            dOuterCylinder  450.0e-6;
             hCylinder       180.0e-6;
             offsetCylinder  0.0e-6;
             position          (0.001 0.0 0.0);

--- a/ECN_Spray_A/constant/volumeFlowRateProfile_p150.foam
+++ b/ECN_Spray_A/constant/volumeFlowRateProfile_p150.foam
@@ -7,8 +7,8 @@
 \*---------------------------------------------------------------------------*/
 
 massTotal       15.4972e-6;
-outerDiameter   89.4000e-6;
-innerDiameter   0.0;
+dOuter          89.4000e-6;
+dInner          0.0;
 Cd              constant 0.9;
 duration        6.1000e-3;
 flowRateProfile table


### PR DESCRIPTION
Update key entries in sprayCloudProperties that correspond to inner/outer diameters of the physical nozzle and the sampling cone/cylinder parcel injection. Such commit brings consistency to the latest fix in https://github.com/Aalto-CFD/ConeCylinderInjection/commit/fa75f0ee7a55f6636b5bbabbb3a4958daf2b7eee 